### PR TITLE
Add battery color indicator

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,3 +40,15 @@
 .read-the-docs {
   color: #888;
 }
+
+.battery-high {
+  color: green;
+}
+
+.battery-medium {
+  color: orange;
+}
+
+.battery-low {
+  color: red;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { io } from 'socket.io-client';
 import type { Telemetry } from './types/Telemetry';
 import { DroneMap } from './components/DroneMap';
+import TelemetryPanel from './components/TelemetryPanel';
 
 const socket = io('http://localhost:5000', {
   transports: ['websocket'],
@@ -41,9 +42,7 @@ function App() {
     <div style={{ padding: '2rem' }}>
       <h2>🔒 Secure Drone Command Center</h2>
       <DroneMap telemetry={telemetry} />
-      <p>🛰️ Lat: {telemetry.lat.toFixed(6)} | Lon: {telemetry.lon.toFixed(6)}</p>
-      <p>🪂 Altitude: {telemetry.altitude.toFixed(1)} m | Speed: {telemetry.speed.toFixed(1)} km/h</p>
-      <p>🔋 Battery: {telemetry.battery.toFixed(1)}%</p>
+      <TelemetryPanel telemetry={telemetry} />
 
       <button onClick={() => sendCommand('RETURN')}>🛬 Return to Base</button>
       <button onClick={() => sendCommand('HOLD')}>⏸️ Hold Position</button>

--- a/frontend/src/components/TelemetryPanel.tsx
+++ b/frontend/src/components/TelemetryPanel.tsx
@@ -1,0 +1,29 @@
+import type { Telemetry } from '../types/Telemetry';
+
+interface Props {
+  telemetry: Telemetry;
+}
+
+const TelemetryPanel = ({ telemetry }: Props) => {
+  const getBatteryClass = (battery: number): string => {
+    if (battery > 50) return 'battery-high';
+    if (battery > 20) return 'battery-medium';
+    return 'battery-low';
+  };
+
+  return (
+    <div>
+      <p>
+        🛰️ Lat: {telemetry.lat.toFixed(6)} | Lon: {telemetry.lon.toFixed(6)}
+      </p>
+      <p>
+        🪂 Altitude: {telemetry.altitude.toFixed(1)} m | Speed: {telemetry.speed.toFixed(1)} km/h
+      </p>
+      <p>
+        🔋 Battery: <span className={getBatteryClass(telemetry.battery)}>{telemetry.battery.toFixed(1)}%</span>
+      </p>
+    </div>
+  );
+};
+
+export default TelemetryPanel;


### PR DESCRIPTION
## Summary
- create TelemetryPanel component to show telemetry values
- color-code battery level via CSS classes
- render TelemetryPanel in App

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*