### PR TITLE
Add telemetry panel component

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,3 +40,18 @@
 .read-the-docs {
   color: #888;
 }
+
+.telemetry-panel {
+  list-style: none;
+  padding: 0;
+  margin: 1rem auto;
+  max-width: 400px;
+  text-align: left;
+}
+
+.telemetry-panel li {
+  margin: 0.25rem 0;
+  background: #1a1a1a;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { io } from 'socket.io-client';
 import type { Telemetry } from './types/Telemetry';
 import { DroneMap } from './components/DroneMap';
+import { TelemetryPanel } from './components/TelemetryPanel';
 
 const socket = io('http://localhost:5000', {
   transports: ['websocket'],
@@ -41,9 +42,7 @@ function App() {
     <div style={{ padding: '2rem' }}>
       <h2>🔒 Secure Drone Command Center</h2>
       <DroneMap telemetry={telemetry} />
-      <p>🛰️ Lat: {telemetry.lat.toFixed(6)} | Lon: {telemetry.lon.toFixed(6)}</p>
-      <p>🪂 Altitude: {telemetry.altitude.toFixed(1)} m | Speed: {telemetry.speed.toFixed(1)} km/h</p>
-      <p>🔋 Battery: {telemetry.battery.toFixed(1)}%</p>
+      <TelemetryPanel telemetry={telemetry} />
 
       <button onClick={() => sendCommand('RETURN')}>🛬 Return to Base</button>
       <button onClick={() => sendCommand('HOLD')}>⏸️ Hold Position</button>

--- a/frontend/src/components/TelemetryPanel.tsx
+++ b/frontend/src/components/TelemetryPanel.tsx
@@ -1,0 +1,17 @@
+import type { Telemetry } from '../types/Telemetry';
+
+type Props = {
+  telemetry: Telemetry;
+};
+
+export const TelemetryPanel = ({ telemetry }: Props) => {
+  return (
+    <ul className="telemetry-panel">
+      <li>Latitude: {telemetry.lat.toFixed(6)}</li>
+      <li>Longitude: {telemetry.lon.toFixed(6)}</li>
+      <li>Altitude: {telemetry.altitude.toFixed(1)} m</li>
+      <li>Speed: {telemetry.speed.toFixed(1)} km/h</li>
+      <li>Battery: {telemetry.battery.toFixed(1)}%</li>
+    </ul>
+  );
+};


### PR DESCRIPTION
## Summary
- display telemetry data in a dedicated panel
- use the panel in the main app UI
- style the panel in App.css
- strip emoji icons from telemetry labels

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*