### PR TITLE
Add telemetry path retrieval and display

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { io } from 'socket.io-client';
 import type { Telemetry } from './types/Telemetry';
+import type { PathPoint } from './types/PathPoint';
 import { DroneMap } from './components/DroneMap';
 import { Header } from './components/Header';
 import './App.css';
@@ -18,8 +19,14 @@ function App() {
     battery: 100,
   });
   const [connected, setConnected] = useState(false);
+  const [path, setPath] = useState<PathPoint[]>([]);
 
   useEffect(() => {
+    fetch('http://localhost:5000/path')
+      .then((res) => res.json())
+      .then((data: PathPoint[]) => setPath(data))
+      .catch((err) => console.error('Failed to load path', err));
+
     socket.on('connect', () => {
       console.log('✅ Connected to backend');
       setConnected(true);
@@ -30,6 +37,7 @@ function App() {
     socket.on('telemetry', (data: Telemetry) => {
       console.log('📡 Telemetry received:', data);
       setTelemetry(data);
+      setPath((prev) => [...prev, { lat: data.lat, lon: data.lon }]);
     });
 
     socket.on('connect_error', (err) => {
@@ -49,7 +57,7 @@ function App() {
     <div className="app-container">
       <Header connected={connected} />
       <main>
-        <DroneMap telemetry={telemetry} />
+        <DroneMap telemetry={telemetry} path={path} />
         <p>
           🛰️ Lat: {telemetry.lat.toFixed(6)} | Lon: {telemetry.lon.toFixed(6)}
         </p>

--- a/frontend/src/components/DroneMap.tsx
+++ b/frontend/src/components/DroneMap.tsx
@@ -1,5 +1,6 @@
-import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup, useMap, Polyline } from 'react-leaflet';
 import type { Telemetry } from '../types/Telemetry';
+import type { PathPoint } from '../types/PathPoint';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
 import { useEffect } from 'react';
@@ -17,6 +18,7 @@ L.Icon.Default.mergeOptions({
 
 type Props = {
   telemetry: Telemetry;
+  path: PathPoint[];
 };
 
 const RecenterMap = ({ lat, lon }: { lat: number; lon: number }) => {
@@ -27,7 +29,7 @@ const RecenterMap = ({ lat, lon }: { lat: number; lon: number }) => {
   return null;
 };
 
-export const DroneMap = ({ telemetry }: Props) => {
+export const DroneMap = ({ telemetry, path }: Props) => {
   return (
     <MapContainer
       center={[telemetry.lat, telemetry.lon]}
@@ -39,6 +41,9 @@ export const DroneMap = ({ telemetry }: Props) => {
         attribution='&copy; OpenStreetMap contributors'
         url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
       />
+      {path.length > 1 && (
+        <Polyline positions={path.map((p) => [p.lat, p.lon])} color='blue' />
+      )}
       <Marker position={[telemetry.lat, telemetry.lon]}>
         <Popup>
           🛰️ Alt: {telemetry.altitude.toFixed(1)} m<br />

--- a/frontend/src/types/PathPoint.ts
+++ b/frontend/src/types/PathPoint.ts
@@ -1,0 +1,4 @@
+export interface PathPoint {
+  lat: number;
+  lon: number;
+}


### PR DESCRIPTION
## Summary
- add DB_FILE constant and telemetry path route to Flask app
- fetch and update path in React app
- show path on the Leaflet map using Polyline
- define `PathPoint` type

## Testing
- `python -m py_compile backend/app.py backend/simulator.py`
- `npx --yes tsc --noEmit -p frontend/tsconfig.app.json` *(fails: Cannot find module 'react')*