### PR TITLE
Use BACKEND_URL env var in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ python simulator.py
 cd frontend
 npm install
 export VITE_COMMAND_TOKEN=mysecret  # Must match COMMAND_TOKEN
+export VITE_BACKEND_URL=http://localhost:5000  # Backend base URL (default)
 npm run dev
 
 # Frontend runs at:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,9 @@ import { Header } from './components/Header';
 import { StatusBadge } from './components/StatusBadge';
 import './App.css';
 
-const socket = io('http://localhost:5000', {
+const BACKEND_URL =
+  import.meta.env.VITE_BACKEND_URL || 'http://localhost:5000';
+const socket = io(BACKEND_URL, {
   transports: ['websocket'],
 });
 const COMMAND_TOKEN = import.meta.env.VITE_COMMAND_TOKEN;
@@ -24,7 +26,8 @@ function App() {
   const [path, setPath] = useState<PathPoint[]>([]);
 
   useEffect(() => {
-    fetch('http://localhost:5000/path')
+    const baseUrl = BACKEND_URL.replace(/\/+$/, '');
+    fetch(`${baseUrl}/path`)
       .then((res) => res.json())
       .then((data: PathPoint[]) => setPath(data))
       .catch((err) => console.error('Failed to load path', err));

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -7,6 +7,7 @@ declare module '*.png' {
 
 interface ImportMetaEnv {
   readonly VITE_COMMAND_TOKEN: string;
+  readonly VITE_BACKEND_URL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- read backend URL from `VITE_BACKEND_URL` in `App.tsx`
- update TypeScript env definitions
- document `VITE_BACKEND_URL` in setup instructions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a4ccc8ad4832cb36cf869da3eb9f0