### PR TITLE
Remove unused cert.pm entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@ dist/
 *.tmp
 # Security certificates and runtime databases
 backend/certs/*.pem
-backend/certs/cert.pm
 backend/db.sqlite
 backend/drone_log.db

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ mkdir -p certs
 openssl req -newkey rsa:2048 -nodes -keyout certs/key.pem \
     -x509 -days 365 -out certs/cert.pem
 
+The backend looks for these files as `cert.pem` and `key.pem` inside the
+`certs` directory when running with TLS enabled.
+
 # Required: set a token to authorize command events
 export COMMAND_TOKEN=mysecret
 


### PR DESCRIPTION
## Summary
- drop obsolete cert.pm ignore
- note expected certificate file names in README

## Testing
- `python -m py_compile backend/app.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a4d6998e0832c8f830cf81b52faa8