### PR TITLE
Fix os import order in backend server

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,6 +3,7 @@ import eventlet
 eventlet.monkey_patch()
 
 import logging
+import os
 
 # Configure logging level via environment variable
 _log_level = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -12,7 +13,6 @@ from flask import Flask, request, jsonify, make_response
 from flask_socketio import SocketIO
 import sqlite3
 from datetime import datetime
-import os
 
 app = Flask(__name__)
 


### PR DESCRIPTION
## Summary
- import `os` before using it in backend app

## Testing
- `python app.py` *(fails: ModuleNotFoundError for 'eventlet')*

------
https://chatgpt.com/codex/tasks/task_e_684a4f8535cc832c9cc6ea97c58caa34