### PR TITLE
Add configurable TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ openssl req -newkey rsa:2048 -nodes -keyout certs/key.pem \
 The backend looks for these files as `cert.pem` and `key.pem` inside the
 `certs` directory when running with TLS enabled.
 
+To customize the certificate paths, set `TLS_CERT` and `TLS_KEY`. TLS is used
+automatically when both files exist, or you can force it with `USE_TLS=true`:
+
+```bash
+export TLS_CERT=certs/cert.pem
+export TLS_KEY=certs/key.pem
+# Optional: force TLS even if the files do not exist
+export USE_TLS=true
+```
+
 # Required: set a token to authorize command events
 export COMMAND_TOKEN=mysecret
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -27,6 +27,11 @@ socketio = SocketIO(app, cors_allowed_origins=CORS_LIST, async_mode="eventlet")
 
 DB_FILE = os.getenv("TELEMETRY_DB", "telemetry.db")
 
+# TLS configuration
+TLS_CERT = os.getenv("TLS_CERT", "certs/cert.pem")
+TLS_KEY = os.getenv("TLS_KEY", "certs/key.pem")
+USE_TLS = os.getenv("USE_TLS", "false").lower() in ("1", "true", "yes")
+
 # Require a command token for issuing control commands
 COMMAND_TOKEN = os.environ.get("COMMAND_TOKEN")
 if not COMMAND_TOKEN:
@@ -87,5 +92,11 @@ def get_path():
     return resp
 
 if __name__ == "__main__":
-    socketio.run(app, host='0.0.0.0', port=5000)
+    ssl_ctx = None
+    if USE_TLS or (os.path.exists(TLS_CERT) and os.path.exists(TLS_KEY)):
+        ssl_ctx = (TLS_CERT, TLS_KEY)
+    run_kwargs = {}
+    if ssl_ctx:
+        run_kwargs["ssl_context"] = ssl_ctx
+    socketio.run(app, host='0.0.0.0', port=5000, **run_kwargs)
 


### PR DESCRIPTION
## Summary
- add environment variables `TLS_CERT`, `TLS_KEY` and `USE_TLS`
- pass `ssl_context` to `socketio.run` when TLS should be enabled
- document TLS environment variables in README

## Testing
- `python -m py_compile backend/app.py`
- `python -m py_compile backend/simulator.py`


------
https://chatgpt.com/codex/tasks/task_e_684a504891c0832cb07fccd65bf1ebbc