### PR TITLE
Add configurable server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ export COMMAND_TOKEN=mysecret
 # Optional: restrict allowed CORS origins (comma separated)
 export ALLOWED_ORIGINS=http://localhost:5173
 
+# Optional: change the backend port (defaults to 5000)
+export PORT=8000
+
 # 3. Start the Flask server
 python app.py
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -27,6 +27,8 @@ socketio = SocketIO(app, cors_allowed_origins=CORS_LIST, async_mode="eventlet")
 
 DB_FILE = os.getenv("TELEMETRY_DB", "telemetry.db")
 
+PORT = int(os.getenv("PORT", "5000"))
+
 # TLS configuration
 TLS_CERT = os.getenv("TLS_CERT", "certs/cert.pem")
 TLS_KEY = os.getenv("TLS_KEY", "certs/key.pem")
@@ -98,5 +100,5 @@ if __name__ == "__main__":
     run_kwargs = {}
     if ssl_ctx:
         run_kwargs["ssl_context"] = ssl_ctx
-    socketio.run(app, host='0.0.0.0', port=5000, **run_kwargs)
+    socketio.run(app, host='0.0.0.0', port=PORT, **run_kwargs)
 


### PR DESCRIPTION
## Summary
- allow setting PORT environment variable in backend
- use PORT in socketio.run
- document the PORT variable in README

## Testing
- `python -m py_compile backend/app.py backend/simulator.py`


------
https://chatgpt.com/codex/tasks/task_e_684a50cc3b60832c98f8f69b41f0ce5f