### PR TITLE
Add dotenv support and example env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ cd secure-drone-control
 
 # 2. Backend Setup (Python 3.9+)
 cd backend
+cp .env.example .env  # create local environment file
 python -m venv venv
 
 # On Windows

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,9 @@
+COMMAND_TOKEN=example
+PORT=5000
+ALLOWED_ORIGINS=http://localhost:5173
+LOG_LEVEL=INFO
+TELEMETRY_DB=telemetry.db
+TLS_CERT=certs/cert.pem
+TLS_KEY=certs/key.pem
+USE_TLS=false
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -4,6 +4,9 @@ eventlet.monkey_patch()
 
 import logging
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Configure logging level via environment variable
 _log_level = os.getenv("LOG_LEVEL", "INFO").upper()


### PR DESCRIPTION
## Summary
- add dotenv support to backend
- add backend/.env.example
- document copying example env file in README

## Testing
- `python -m py_compile backend/app.py backend/simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_684a53c1a2cc832cbeea0cd3f7c7f146