### PR TITLE
Add docker compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment for docker compose
+PORT=5000
+COMMAND_TOKEN=example
+ALLOWED_ORIGINS=http://localhost:5173
+LOG_LEVEL=INFO
+TELEMETRY_DB=telemetry.db
+TLS_CERT=certs/cert.pem
+TLS_KEY=certs/key.pem
+USE_TLS=false
+VITE_COMMAND_TOKEN=example
+VITE_BACKEND_URL=http://backend:5000

--- a/README.md
+++ b/README.md
@@ -103,3 +103,15 @@ npm run dev
 # Frontend runs at:
 http://localhost:5173
 
+
+---
+
+## Docker Compose Quickstart
+
+1. Copy `backend/.env.example` to `.env` in the repository root and adjust any variables you need.
+2. Build and start the whole stack:
+   ```bash
+   docker compose up --build
+   ```
+   The backend will be available at http://localhost:5000 (or whichever port you set in .env) and the frontend at http://localhost:5173.
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "app.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+services:
+  backend:
+    build: ./backend
+    env_file: .env
+    volumes:
+      - ./backend:/app
+    ports:
+      - "${PORT:-5000}:${PORT:-5000}"
+  simulator:
+    build: ./backend
+    command: python simulator.py
+    depends_on:
+      - backend
+    env_file: .env
+  frontend:
+    build: ./frontend
+    env_file: .env
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "5173:5173"
+    command: npm run dev -- --host
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary
- add sample environment variables for Docker Compose
- add backend and frontend Dockerfiles
- create docker-compose config for backend, simulator and frontend
- document how to start the stack with Docker Compose

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5463b9c0832ca9712cdd23591e10