### PR TITLE
Add local dev start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,4 +114,8 @@ http://localhost:5173
    docker compose up --build
    ```
    The backend will be available at http://localhost:5000 (or whichever port you set in .env) and the frontend at http://localhost:5173.
+3. Alternatively, if you have the Python and Node dependencies installed locally, you can run the stack directly:
+   ```bash
+   ./scripts/start.sh
+   ```
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+# Move to repo root if executed from elsewhere
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Load environment variables from .env if it exists
+if [ -f .env ]; then
+  echo "Loading environment variables from .env"
+  set -a
+  # shellcheck disable=SC1091
+  . .env
+  set +a
+fi
+
+# Start backend server
+echo "Starting backend..."
+cd backend
+python app.py &
+BACKEND_PID=$!
+
+# Start simulator
+echo "Starting simulator..."
+python simulator.py &
+SIM_PID=$!
+cd ..
+
+# Ensure background processes are cleaned up on exit
+trap 'kill $BACKEND_PID $SIM_PID' EXIT
+
+# Start frontend dev server
+cd frontend
+npm run dev
+


### PR DESCRIPTION
## Summary
- add `scripts/start.sh` to launch backend, simulator and frontend
- document the new script as an alternative in the Docker section

## Testing
- `python -m py_compile backend/*.py`
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a55baa620832cbc36638eb4a4c95a